### PR TITLE
OpenAI API を使った用語解説の検索処理を実装

### DIFF
--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,4 +1,5 @@
 class TermsController < ApplicationController
+
   def index
   end
 
@@ -19,7 +20,7 @@ class TermsController < ApplicationController
 
     ai_text = response.dig("choices", 0, "message", "content")
 
-    # View に渡す形に整える（MVP では単純に text を渡せばOK）
+    # Viewに渡す
     @result = {
       title: query,
       description: ai_text,

--- a/app/views/terms/_result.html.erb
+++ b/app/views/terms/_result.html.erb
@@ -1,14 +1,17 @@
 <% if @result.present? %>
   <div class="card bg-base-200 mt-10 shadow max-w-4xl mx-auto min-h-[450px] p-10">
 
+    <!-- 検索用語 -->
     <h2 class="text-2xl font-bold mb-4">
       <%= @result[:title] %>
     </h2>
 
+    <!-- 解説本文 -->
     <p class="leading-relaxed text-lg mb-4">
       <%= @result[:description] %>
     </p>
 
+    <!-- 補足情報 -->
     <% if @result[:supplement].present? %>
       <div class="mt-4 text-base text-gray-600">
         <%= @result[:supplement] %>

--- a/app/views/terms/index.html.erb
+++ b/app/views/terms/index.html.erb
@@ -1,7 +1,7 @@
 <div class="max-w-3xl mx-auto mt-32 px-4">
   <!-- 説明文 -->
   <p class="text-center text-base-content/80 font-medium mb-6">
-    わからない野球用語を入力してください
+    知りたい野球用語を入力してください
   </p>
 
   <!-- 検索フォーム -->


### PR DESCRIPTION
## 概要

**ユーザーが検索した用語に対して、OpenAI API を利用して解説を返す機能**

1.  `query = params[:query]`
- 検索用語を取得

2. `client = OpenAI::Client.new`
- APIキー付きの通信準備
- OpenAIの API にリクエストを送る
- レスポンスを受け取る

3.  `messages` 配列 OpenAI API に「質問」を投げて、AIから「回答」をもらっている
- openAI の **Chat API** を呼び出す
- モデルの指定

4. `ai_text = response.dig("choices", 0, "message", "content")`
- AIのレスポンスから、本文を抜け出す

5. `view` に渡す
- `title` → ユーザーが入力した検索用語
- `description` → AI が生成した説明本文
- `@result`がviewに渡すためのデータ