### PR TITLE
利用規約ページ作成

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,10 @@
 class PagesController < ApplicationController
   def contact
   end
+
   def how_to_use
+  end
+
+  def terms
   end
 end

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,0 +1,80 @@
+<h1 class="text-2xl font-bold mb-6">利用規約</h1>
+
+<div class="space-y-6 text-sm text-gray-700 leading-relaxed">
+  <p>
+    本利用規約（以下「本規約」）は、本サービス「yakyu-coach-ai」（以下「本サービス」）の利用条件を定めるものです。
+  </p>
+
+  <section>
+    <h2 class="font-semibold text-base mb-2">第1条（適用）</h2>
+    <p>
+      本規約は、ユーザーと本サービス提供者との間の、本サービスの利用に関わる一切の関係に適用されます。
+    </p>
+  </section>
+
+  <section>
+    <h2 class="font-semibold text-base mb-2">第2条（サービス内容）</h2>
+    <p>
+      本サービスは、野球用語を入力することで、AIが利用者の理解度（初心者・中級者・上級者）に応じた解説を提供する学習支援サービスです。
+    </p>
+    <p class="mt-2">
+      本サービスの内容は、予告なく変更・追加・停止されることがあります。
+    </p>
+  </section>
+
+  <section>
+    <h2 class="font-semibold text-base mb-2">第3条（禁止事項）</h2>
+    <ul class="list-disc pl-5 space-y-1">
+      <li>法令または公序良俗に違反する行為</li>
+      <li>本サービスの運営を妨害する行為</li>
+      <li>不正アクセス、またはこれを試みる行為</li>
+      <li>本サービスを本来の目的以外で利用する行為</li>
+      <li>本サービスの趣旨に反する内容（野球用語と無関係な用語等）を入力する行為</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2 class="font-semibold text-base mb-2">第4条（免責事項）</h2>
+    <p>
+      本サービスで提供されるAIによる解説内容の正確性・完全性・有用性について、保証するものではありません。
+    </p>
+    <p class="mt-2">
+      本サービスの利用により生じた損害について、運営者は一切の責任を負いません。
+    </p>
+    <p class="mt-2">
+      本サービスは、学習・参考目的での利用を想定しています。
+    </p>
+  </section>
+
+  <section>
+    <h2 class="font-semibold text-base mb-2">第5条（サービスの停止・中断）</h2>
+    <p>
+      運営者は、システム保守、障害、その他必要と判断した場合、事前の通知なく本サービスを停止または中断できるものとします。
+    </p>
+  </section>
+
+  <section>
+    <h2 class="font-semibold text-base mb-2">第6条（利用規約の変更）</h2>
+    <p>
+      運営者は、必要と判断した場合、本規約を変更することがあります。変更後の規約は、本サービス上に表示した時点で効力を生じるものとします。
+    </p>
+  </section>
+
+  <section>
+    <h2 class="font-semibold text-base mb-2">第7条（準拠法・管轄）</h2>
+    <p>
+      本規約の解釈にあたっては、日本法を準拠法とします。
+    </p>
+  </section>
+
+  <section>
+    <h2 class="font-semibold text-base mb-2">第8条（アカウント管理）</h2>
+    <p class="mt-2">
+      ユーザーは、自己の責任において本サービスのアカウントを管理するものとします。
+    </p>
+    <p class="mt-2">
+      第三者による不正利用があった場合でも、運営者は一切の責任を負わないものとします。
+    </p>
+  </section>
+</div>
+

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <div class="flex justify-center space-x-8 text-sm">
 
       <%= link_to t("footer.contact"), contact_path %>
-      <%= link_to t("footer.terms"), "#" %>
+      <%= link_to t("footer.terms"), terms_of_service_path %>
       <%= link_to t("footer.privacy"), "#" %>
 
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,5 +20,6 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
   get "/how_to_use", to: "pages#how_to_use"
   get "/contact", to: "pages#contact"
+  get "/terms_of_service", to: "pages#terms"
 
 end


### PR DESCRIPTION
### 概要

**利用規約ページを新規作成**

### 実装概要
- PagesController に `terms` アクションを追加
- 利用規約ページ（terms.html.erb）を新規作成
- 検索用 `terms` との衝突を避けるため、`/terms_of_service` をルーティングに追加
- フッターの利用規約リンクに `terms_of_service_path` を設定