### PR TITLE
AIレスポンスから関連用語を分離して表示するように修正

### DIFF
--- a/app/services/ai/search_service.rb
+++ b/app/services/ai/search_service.rb
@@ -31,16 +31,28 @@ module Ai
     end
 
     def call_openai(term)
-      prompt = Ai::PromptBuilder.build(
-          word: term,
-          level: @level
-      )
+      prompt = Ai::PromptBuilder.build(word: term, level: @level)
+      raw = Ai::OpenaiClient.call(prompt)
 
-      response = Ai::OpenaiClient.call(prompt)
+      description = raw[:description]
+      related_terms = []
+
+      # description の末尾に JSON が混ざっている場合を分離
+      if description.is_a?(String) && description.include?('"related_terms"')
+        json_part = description.match(/\{[\s\S]*\}\s*\z/)&.to_s
+        text_part = description.sub(json_part.to_s, "").strip
+
+        begin
+          parsed = JSON.parse(json_part)
+          related_terms = Array(parsed["related_terms"])
+          description = text_part
+        rescue JSON::ParserError
+        end
+      end
 
       {
-          description: response[:description],
-          related_terms: response[:related_terms]
+        description: description,
+        related_terms: related_terms
       }
     end
   end


### PR DESCRIPTION
## 概要

**OpenAIのレスポンスに解説文と関連用語のJSONが混在していたため、解説文と関連用語を分離して正しく表示できるように修正**

### 実装詳細
- OpenAIのレスポンスに解説文と関連用語のJSONが混在するケースに対応するため、Service層でレスポンスを正規化する処理を追加
- related_terms を空配列で初期化
- 解説文の末尾に JSON が含まれているかを判定
- 正規表現で JSON 部分を抽出し、JSON.parse で Ruby の Hash に変換
- 解説文と関連用語を分離し、それぞれを正しい形式で表示