### PR TITLE
GitHub actions cd 設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,15 @@
 name: CD
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 jobs:
   deploy:
-    name: Deploy to Render
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-
-    # CI が成功した場合のみ実行
-    needs: test
 
     steps:
       - name: Trigger Render Deploy Hook


### PR DESCRIPTION
## 概要

**main ブランチへのマージを行なったときに、Render へのデプロイを自動実行する GitHub Actions（CD）を設定**

### 実装概要
- GitHub Actions の CD 用 workflow（deploy.yml）を新規作成
- main ブランチへの push（マージ）時に CD が実行されるように設定
- CI が成功した場合のみ、Render のデプロイを実行