### PR TITLE
本番環境でRedisに接続できるようREDIS_URLを使用するよう修正

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,1 +1,3 @@
-REDIS = Redis.new(url: "redis://redis:6379/0")
+REDIS = Redis.new(
+  url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0")
+)


### PR DESCRIPTION
## 概要

**本番環境で Redis に接続できなかった問題を修正**

### 実装概要
- config/initializers/redis.rb を修正し、本番環境では REDIS_URL（環境変数）から Redis の接続先を取得するように変更
- ローカル環境では localhost を使用するように設定