### PR TITLE
DB設計の見直し

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ https://yakyucoach.com/
 - [画面遷移図（Figma）](https://www.figma.com/design/8WVZxTzZAwlwzfKY0MoGwV/無題?node-id=0-1&t=YxwhpswlSKCxnMPF-1)
 
 ## ER図
-![ER図](https://i.gyazo.com/8be550529b123fa2e5f12f7367b511e4.png)
+![ER図](https://i.gyazo.com/6b3c3e24895aa4f466e652e8477a8935.png)

--- a/db/migrate/20260331140749_drop_baseball_terms.rb
+++ b/db/migrate/20260331140749_drop_baseball_terms.rb
@@ -1,0 +1,5 @@
+class DropBaseballTerms < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :baseball_terms
+  end
+end

--- a/db/migrate/20260331141022_drop_posts.rb
+++ b/db/migrate/20260331141022_drop_posts.rb
@@ -1,0 +1,5 @@
+class DropPosts < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :posts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_04_120407) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_31_140749) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,13 +22,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_04_120407) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["term", "level"], name: "index_ai_results_on_term_and_level", unique: true
-  end
-
-  create_table "baseball_terms", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_baseball_terms_on_name"
   end
 
   create_table "bookmarks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_31_140749) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_31_141022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,12 +32,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_31_140749) do
     t.index ["ai_result_id"], name: "index_bookmarks_on_ai_result_id"
     t.index ["user_id", "ai_result_id"], name: "index_bookmarks_on_user_id_and_ai_result_id", unique: true
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
-  end
-
-  create_table "posts", force: :cascade do |t|
-    t.string "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## 概要

DB設計の見直しとして、不要なテーブルの削除を実施

### 作業内容
- 今回のアプリではユーザーの検索語に対してAIが生成した解説結果をキャッシュとして保存する設計のため、用語を管理する必要はないと考えたので、`baseball_terms`テーブルを削除
- `posts`テーブルは開発初期のデプロイ目的で作成したものでアプリの目的とは関係ないため削除